### PR TITLE
Partly fix the preview pane.

### DIFF
--- a/app/views/proposals/_contents.html.haml
+++ b/app/views/proposals/_contents.html.haml
@@ -4,8 +4,13 @@
     = proposal.occurrencesView
 
 .proposal-section
+  %h3.control-label Title
+  %div{ data: { 'field-id' => 'proposal_title' } }
+    = proposal.title
+
+.proposal-section
   %h3.control-label Keywords
-  %div
+  %div{ data: { 'field-id' => 'proposal_keywords' } }
     = proposal.keywords
 
 .proposal-section


### PR DESCRIPTION
Correctly show the proposal title and keywords.

Unfortunately, I’ve been unable to fix the preview of the following fields: events, session format and track. These are not just text fields so the strategy used to show the other fields doesn’t work on them. Note that in the current cfp-app the same limitation exists (it’s not due to our modifications).